### PR TITLE
Make sure the go_to path is a valid UTF-8 string

### DIFF
--- a/lib/go_to_param.rb
+++ b/lib/go_to_param.rb
@@ -47,7 +47,7 @@ module GoToParam
 
   def go_to_here_path(additional_query_params = {})
     if request.get?
-      _go_to_add_query_string_from_hash(request.fullpath, additional_query_params)
+      _go_to_add_query_string_from_hash(_utf8_request_full_path, additional_query_params)
     else
       nil
     end
@@ -66,5 +66,12 @@ module GoToParam
       query_string = hash.map { |k, v| "#{k}=#{CGI.escape v.to_s}" }.join("&")
       [ path, separator, query_string ].join
     end
+  end
+
+  # Prevent encoding errors (incompatible character encodings: UTF-8 and ASCII-8BIT...)
+  # Inspired on https://github.com/discourse/discourse/commit/090dc80f8a23dbb3ad703efbac990aa917c06505
+  def _utf8_request_full_path
+    path = request.fullpath
+    path.dup.force_encoding("UTF-8").scrub
   end
 end

--- a/spec/go_to_param_spec.rb
+++ b/spec/go_to_param_spec.rb
@@ -99,6 +99,18 @@ describe GoToParam do
       expect(controller.go_to_here_params(bar: 3)).to eq({ go_to: "/example?foo&bar=3" })
     end
 
+    it "makes sure the request path to go to is a valid utf8 string" do
+      weird_path = "\xE0\x80\x80"
+      weird_path.force_encoding("ASCII-8BIT")
+      weird_path << "weird\330stuff".force_encoding("ASCII-8BIT")
+
+      replacement = "\uFFFD"
+
+      controller.request = double(get?: true, fullpath: weird_path)
+
+      expect(controller.go_to_here_params[:go_to].encoding).to eq(Encoding::UTF_8)
+      expect(controller.go_to_here_params).to eq(go_to: "#{replacement}#{replacement}#{replacement}weird#{replacement}stuff")
+    end
   end
 
   describe "#go_to_path" do


### PR DESCRIPTION
This change prevents errors like `ActionView::Template::Error: incompatible character encodings: UTF-8 and ASCII-8BIT` when using the helpers.

The problem is due to the fact that `request.fullpath` isn't guaranteed to be a valid UTF-8 string, but it ends up being concatenated into the rendering view buffer which is UTF-8.