### PR TITLE
adding whitelist support to go_to_param

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ Or install it yourself as:
 
     $ gem install go_to_param
 
+## Configuration
+
+If you need to redirect out of your web application, like to a ios app using a protocol, you can configure go_to_param to allow
+this. Just set the allowed prefix in an initializer:
+
+```ruby
+GoToParam.add_to_allowed_redirect_prefixes("myapp://")
+```
+
 ## License
 
 Copyright (c) 2013 Henrik Nyh

--- a/spec/go_to_param_spec.rb
+++ b/spec/go_to_param_spec.rb
@@ -144,4 +144,14 @@ describe GoToParam do
       expect(controller.go_to_path_or("/default")).to eq("/default")
     end
   end
+
+  describe "providing additional allowed redirect prefixes" do
+    it "accepts setting additional allowed redirect prefixes, like an ios app protocol prefix" do
+      # This changes the class variable, and leaks to the other tests, but it does not interfere with any other spec.
+      GoToParam.add_to_allowed_redirect_prefixes("myapp://")
+
+      controller.params = { go_to: "myapp://", id: "1" }
+      expect(controller.go_to_path).to eq("myapp://")
+    end
+  end
 end


### PR DESCRIPTION
Also added the whitelist option to the other public go_to methods.