### PR TITLE
Avoid a Ruby 2.7 deprecation warning

### DIFF
--- a/lib/go_to_param.rb
+++ b/lib/go_to_param.rb
@@ -35,7 +35,7 @@ module GoToParam
   end
 
   def go_to_here_params(additional_query_params = {})
-    path = go_to_here_path(additional_query_params)
+    path = go_to_here_path(**additional_query_params)
 
     if path
       { go_to: path }


### PR DESCRIPTION
This PR makes the code avoid this warning:

> "warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call ;"